### PR TITLE
Add load_name for ansible 2.9 compatability

### DIFF
--- a/plugins/connection/eci.py
+++ b/plugins/connection/eci.py
@@ -333,6 +333,7 @@ class Connection(ssh.Connection):
 
     def __init__(self, *args, **kwargs):
         ssh.Connection.__init__(self, *args, **kwargs)
+        self._load_name = self.__module__.split('.')[-1]
         self.set_options()
 
         if self._play_context.private_key_file:


### PR DESCRIPTION
Ansible 2.9 requires that the module has a "_load_name" set when enabling.

Using the file name without the .py extension to set the "_load_name" so assuming this is copied into the plugins/connections folder as eci.py it will set the _load_name as "eci"