### PR TITLE
use load_ssh_private_key for existing keys

### DIFF
--- a/plugins/connection/eci.py
+++ b/plugins/connection/eci.py
@@ -340,7 +340,7 @@ except ImportError:
 try:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+    from cryptography.hazmat.primitives.serialization.ssh import load_ssh_private_key
     from cryptography.hazmat.primitives.asymmetric import rsa
     from cryptography.hazmat.primitives import serialization
     HAS_CRYPTOGRAPHY = True
@@ -371,7 +371,7 @@ class Connection(ssh.Connection):
 
         if self._play_context.private_key_file:
           display.vvv("EXISTING PRIVATE KEY FILE AVAILABLE, USING IT")
-          self._private_key = load_pem_private_key(self._play_context.private_key_file, None, default_backend())
+          self._private_key = load_ssh_private_key(open(self._play_context.private_key_file, 'rb').read(), None, default_backend())
         else:
           display.vvv("NO PRIVATE KEY FILE, GENERATING ON DEMAND")
           (self._play_context.private_key_file, self._private_key) = self._create_temporary_key()


### PR DESCRIPTION
First of all thanks for releasing this useful plugin!

I tried playing around with using an existing key to speed up performance but kept hitting the following error:
```
  File "/home/oofnikj/.ansible/plugins/connection/eci.py", line 374, in __init__
    self._private_key = load_pem_private_key(open(self._play_context.private_key_file, 'rb').read(), None, default_backend())
  File "/usr/lib64/python3.9/site-packages/cryptography/hazmat/primitives/serialization/base.py", line 20, in load_pem_private_key
    return backend.load_pem_private_key(data, password)
  File "/usr/lib64/python3.9/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1217, in load_pem_private_key
    return self._load_key(
  File "/usr/lib64/python3.9/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1448, in _load_key
    self._handle_key_loading_error()
  File "/usr/lib64/python3.9/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1490, in _handle_key_loading_error
    raise ValueError(
ValueError: Could not deserialize key data. The data may be in an incorrect format or it may be encrypted with an unsupported algorithm.
```

I realized the problem was two-fold:
1. `load_pem_private_key` expects a byte string with the file contents, not a filename
2. `load_pem_private_key` is not equipped to handle OpenSSH private keys.

With these changes I was able to load my existing RSA key successfully and speed up my playbooks a bit. 