### PR TITLE
correct issues with 'reconnection_retries' and 'pkcs11_provider'

### DIFF
--- a/plugins/connection/eci.py
+++ b/plugins/connection/eci.py
@@ -157,7 +157,7 @@ DOCUMENTATION = '''
             - key: ssh_extra_args
               section: ssh_connection
               version_added: '2.7'
-      retries:
+      reconnection_retries:
           # constant: ANSIBLE_SSH_RETRIES
           description: Number of attempts to connect.
           default: 3

--- a/plugins/connection/eci.py
+++ b/plugins/connection/eci.py
@@ -172,6 +172,17 @@ DOCUMENTATION = '''
           vars:
             - name: ansible_ssh_retries
               version_added: '2.7'
+      pkcs11_provider:
+          version_added: '2.12'
+          default: ""
+          description:
+            - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
+            - "Requires sshpass version 1.06+, sshpass must support the -P option."
+          env: [{name: ANSIBLE_PKCS11_PROVIDER}]
+          ini:
+            - {key: pkcs11_provider, section: ssh_connection}
+          vars:
+            - name: ansible_ssh_pkcs11_provider
       port:
           description: Remote port to connect to.
           type: int


### PR DESCRIPTION
[calscoo](https://github.com/calscoo) and I collaborated together on this one.

This fixes #19 by updating the `DOCUMENTATION` block with the latest requirements as demanded by `ansible-core` 2.12.0, in `lib/ansible/plugins/connection/ssh.py`.

[calscoo](https://github.com/calscoo) and I are by no means python experts, so we didn't touch the requirements file, but I imagine that probably needs to be updated as well.