### PR TITLE
Remove now unused ECI_KEY_SIZE and ECI_KEY_EXPONENT

### DIFF
--- a/plugins/connection/eci.py
+++ b/plugins/connection/eci.py
@@ -505,8 +505,6 @@ except ImportError:
 
 
 ECI_PUSH_EXPIRY = 45
-ECI_KEY_SIZE = 2048
-ECI_KEY_EXPONENT = 65537
 
 ECI_CACHE_KEY_FILE = "key_file"
 ECI_CACHE_LAST_PUSH = "last_push"


### PR DESCRIPTION
Hi,

When you re-implemented the changes proposed in https://github.com/mpieters3/ansible-eci-connector/pull/27, it looks like those two constant definitions remained behind, and are now unused, we should probably remove them now :)

